### PR TITLE
Update response value for 10 Request GET

### DIFF
--- a/docs/entity-relationships.md
+++ b/docs/entity-relationships.md
@@ -594,7 +594,7 @@ curl -G -X GET \
 #### Response:
 
 ```json
-[["urn:ngsi-ld:Product:prod001"]]
+[["urn:ngsi-ld:Product:001"]]
 ```
 
 Similarly we can request _Which stores are selling `urn:ngsi-ld:Product:001`?_


### PR DESCRIPTION
Update response value to match previous POST value used in the example.

Also, Postman collection referenced on the page does not have a GET request for the 10 Request example. I used the following: http://{{orion}}/v2/entities/?q=refStore==urn:ngsi-ld:Store:001&options=values&attrs=refProduct&type=InventoryItem