### PR TITLE
Typo and possible error

### DIFF
--- a/docs/identity-management.md
+++ b/docs/identity-management.md
@@ -852,7 +852,7 @@ The response returns the details of the organization.
 
 ### List all Organizations
 
-Obtaining a complete list of all users is a super-admin permission requiring the `X-Auth-token` - most users will only
+Obtaining a complete list of all organizations is a super-admin permission requiring the `X-Auth-token` - most users will only
 be permitted to return users within their own organization. Listing users can be done by making a GET request to the
 `/v1/organizations` endpoint
 


### PR DESCRIPTION
Typo in ### List all Organizations. 
Not sure if an admin can retrieve all the organizations through the API, though. I've done a test after removing admin from an organisation in GUI and the response is a 403:
```
{
    "error": {
        "message": "User not allow to perform the action",
        "code": 403,
        "title": "Forbidden"
    }
}
```