### PR TITLE
Removed --smallfiles from mongoDB execution

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,7 @@ with the following command:
 
 ```bash
 docker run -d --name=mongo-db --network=fiware_default \
-  --expose=27017 mongo:4.2 --bind_ip_all --smallfiles
+  --expose=27017 mongo:4.2 --bind_ip_all
 ```
 
 The Orion Context Broker can be started and connected to the network with the following command:


### PR DESCRIPTION
Since --smallfiles is not supported in mongoDB ver4.2, when it is executed, a warning "Error parsing command line: unrecognized option'--smallfiles'" is written in the log and it stops working, so I deleted it.